### PR TITLE
restrict allowable strings for rundir

### DIFF
--- a/analysis/osiris.py
+++ b/analysis/osiris.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 import subprocess
 import IPython.display
@@ -44,8 +45,12 @@ def execute(cmd):
 
 def run_upic_es(rundir='',inputfile='pinput2',np=None):
 
-    if rundir == '':
-        print('Error:  You must specify a runtime directory name via the rundir parameter.')
+    if rundir == '' or not bool(re.match("^[A-Za-z0-9_-]*$", rundir)):
+        print('''
+        Error for osiris.run_upic_es:
+        rundir must be specified for the name of a runtime directory
+        and rundir must be a string containing only numbers, letters, dashes, or underscores
+        ''')
         return
 
     def combine_h5_2d(path, ex):
@@ -127,8 +132,12 @@ def run_upic_es(rundir='',inputfile='pinput2',np=None):
 
 def runosiris(rundir='',inputfile='osiris-input.txt',print_out='yes',combine='yes',np=None):
 
-    if rundir == '':
-        print('Error:  You must specify a runtime directory name via the rundir parameter.')
+    if rundir == '' or not bool(re.match("^[A-Za-z0-9_-]*$", rundir)):
+        print('''
+        Error for osiris.runosiris:
+        rundir must be specified for the name of a runtime directory
+        and rundir must be a string containing only numbers, letters, dashes, or underscores
+        ''')
         return
 
     def combine_h5_1d(ex):
@@ -231,8 +240,12 @@ def runosiris(rundir='',inputfile='osiris-input.txt',print_out='yes',combine='ye
 
 def runosiris_2d(rundir='',inputfile='osiris-input.txt',print_out='yes',combine='yes',np=None):
 
-    if rundir == '':
-        print('Error:  You must specify a runtime directory name via the rundir parameter.')
+    if rundir == '' or not bool(re.match("^[A-Za-z0-9_-]*$", rundir)):
+        print('''
+        Error for osiris.runosiris_2d:
+        rundir must be specified for the name of a runtime directory
+        and rundir must be a string containing only numbers, letters, dashes, or underscores
+        ''')
         return
 
     def combine_h5_2d(ex):
@@ -261,6 +274,9 @@ def runosiris_2d(rundir='',inputfile='osiris-input.txt',print_out='yes',combine=
     # run osiris-2D.e executable
     if(not os.path.isdir(rundir)):
        os.mkdir(rundir)
+    else:
+        shutil.rmtree(rundir)
+        os.mkdir(rundir)
 
     shutil.copyfile(inputfile,rundir+'/osiris-input.txt')
     waittick = 0

--- a/analysis/quickpic.py
+++ b/analysis/quickpic.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 import subprocess
 import IPython.display
@@ -23,8 +24,12 @@ def execute(cmd):
 
 def runqpic(rundir='',inputfile='qpinput.json'):
 
-    if rundir == '':
-        print('Error:  You must specify a runtime directory name via the rundir parameter.')
+    if rundir == '' or not bool(re.match("^[A-Za-z0-9_-]*$", rundir)):
+        print('''
+        Error for quickpic.runqpic:
+        rundir must be specified for the name of a runtime directory
+        and rundir must be a string containing only numbers, letters, dashes, or underscores
+        ''')
         return
 
     if os.path.isfile('qpic.e'):

--- a/runosdocker
+++ b/runosdocker
@@ -1,1 +1,1 @@
- docker run -it -v $PWD:/home/jovyan --rm -p 8888:8888 picksc/jupyterpic:061319
+ docker run -it -v $PWD:/home/jovyan --rm -p 8888:8888 picksc/jupyterpic:070919


### PR DESCRIPTION
runosiris[_2d], runqpic, and run_upic_es will delete duplicate directories at start -- this restricts allowable values for rundir string to prevent accidental deletions